### PR TITLE
Add 664 permission to files for mounting by docker

### DIFF
--- a/tools/haproxy/configure-haproxy.sh
+++ b/tools/haproxy/configure-haproxy.sh
@@ -34,6 +34,7 @@ EOF
         echo "        server api${size} ${address}:${KUBE_INTERNAL_PORT} check" >> ${TEMPLATE}
         size=$((size+1))
     done
+    chmod 664 ${TEMPLATE}
 
     local TEMPLATE=/etc/kubernetes/manifests/haproxy.yaml
     echo "TEMPLATE: $TEMPLATE"

--- a/tools/haproxy/configure-keepalived.sh
+++ b/tools/haproxy/configure-keepalived.sh
@@ -30,6 +30,7 @@ vrrp_instance VI {
   }
 }
 EOF
+    chmod 664 $TEMPLATE
 
     local TEMPLATE=/etc/kubernetes/manifests/keepalived.yaml
     echo "TEMPLATE: $TEMPLATE"


### PR DESCRIPTION
If file mounted to container has 644 permission, changing contents by vim editor at docker host doesn't sync both docker host and container. 
It is needed 664 permission (add write to group) to sync both docker host and container.
This commit add "chmod 664" operations for files which is mounted by docker.

See below for ref.
https://forums.docker.com/t/modify-a-file-which-mount-as-a-data-volume-but-it-didnt-change-in-container/2813/14
