### PR TITLE
Use pip3 instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ on the top of OpenStack.
 Remora requires some dependencies, so it's needed to install.
 
 ```bash
-$ pip install -r requirements.txt
+$ pip3 install -r requirements.txt
 ```
 
 And also Remora will use `kubectl` command. So please install `kubectl`.


### PR DESCRIPTION
remora supports only py3, so it would be nice to specify pip3 clearly
to represent that.