### PR TITLE
Add debug message

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ on the top of OpenStack.
 Remora requires some dependencies, so it's needed to install.
 
 ```bash
-$ pip install -r requirements.txt
+$ pip3 install -r requirements.txt
 ```
 
 And also Remora will use `kubectl` command. So please install `kubectl`.

--- a/remora/scripts/kubernetes/render-installer.sh
+++ b/remora/scripts/kubernetes/render-installer.sh
@@ -11,9 +11,10 @@ set -eu
 export LC_ALL=C
 ROOT=$(dirname "${BASH_SOURCE}")
 
+echo "Start to wait for Kubernetes API (https://${KUBE_PUBLIC_SERVICE_IP}:${KUBE_PORT}/healthz)"
 until curl -skf "https://${KUBE_PUBLIC_SERVICE_IP}:${KUBE_PORT}/healthz"
 do
-    echo "Waiting for Kubernetes API..."
+    echo "Still waiting for Kubernetes API..."
     sleep 5
 done
 


### PR DESCRIPTION
The main purpose of https://github.com/nec-openstack/remora/pull/14/commits/13af8224791ba0fa516376b1ef51a29a80bab681 is that remora sets 6443 as k8s tcp port, and that is the original one.
So users need to set the security group of master virtual machine to allow the port before, but that is not described and hard to do that. 
